### PR TITLE
Extending object in ember-way manner

### DIFF
--- a/addon/config.js
+++ b/addon/config.js
@@ -13,8 +13,7 @@ export default Em.Namespace.extend({
   addConfig: function(name, config) {
     var defaultConfig, newConfig;
     defaultConfig = this._configs.get('default');
-    newConfig = Em.Object.create(config);
-    newConfig = Em.$.extend(true, newConfig, defaultConfig);
+    newConfig = Em.Object.create(defaultConfig, config);
     return this._configs.set(name, newConfig);
   }
 });


### PR DESCRIPTION
When we are trying to extend object by jquery extend method, application will fail because property isDestroyed can be updated by destroy() method only.
Configuration:
ember@2.11.2
jquery@1.12.4